### PR TITLE
Add groupings to examples

### DIFF
--- a/mdx/groups.json
+++ b/mdx/groups.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://registry.steel-edge.net/schemas/v1/registry-groups.json",
+  "examples": [
+    {
+      "id": "playwright-starter",
+      "title": "Using Playwright with Steel",
+      "accentColor": "blue",
+      "category": "BROWSER_AUTOMATION",
+      "description": "A starter project for using Playwright with Steel",
+      "flags": ["cli", "guide", "playground"]
+    },
+    {
+      "id": "puppeteer-starter",
+      "title": "Using Puppeteer with Steel",
+      "accentColor": "yellow",
+      "category": "BROWSER_AUTOMATION",
+      "description": "A starter project for using Puppeteer with Steel",
+      "flags": ["cli", "guide", "playground"]
+    },
+    {
+      "id": "oai-computer-use",
+      "title": "Using Steel with OpenAI's Computer Use API",
+      "accentColor": "orange",
+      "category": "AI_AUTOMATION",
+      "description": "Create a browser automation agent with Steel and OpenAI's Computer Use Assistant.",
+      "flags": ["cli", "playground"]
+    },
+    {
+      "id": "claude-computer-use",
+      "title": "Using Steel with Claude's Computer Use API",
+      "accentColor": "purple",
+      "category": "AI_AUTOMATION",
+      "description": "Create a browser automation agent with Steel and Claude's Computer Use API.",
+      "flags": ["cli", "playground"]
+    },
+    {
+      "id": "stagehand-starter",
+      "title": "Using Steel with Stagehand for AI-Powered Automations",
+      "accentColor": "green",
+      "category": "AI_AUTOMATION",
+      "description": "A starter project demonstrating how to use Steel with Stagehand for AI-powered browser automations.",
+      "flags": ["cli", "playground"]
+    }
+  ]
+}

--- a/mdx/playwright-python.mdx
+++ b/mdx/playwright-python.mdx
@@ -5,8 +5,9 @@ accentColor: "blue"
 category: "BROWSER_AUTOMATION"
 stack: "python"
 description: "Control Steel's managed browser infrastructure with Playwright in Python for reliable web automation without the headaches."
-flags: ["guide", "playground"]
+flags: ["guide", "playground", "cli"]
 directory: "examples/steel-playwright-python-starter"
+groupId: "playwright-starter"
 language: "python"
 ---
 

--- a/mdx/playwright-typescript.mdx
+++ b/mdx/playwright-typescript.mdx
@@ -5,8 +5,9 @@ accentColor: "orange"
 category: "BROWSER_AUTOMATION"
 stack: "nodejs"
 description: "Control Steel's managed browser infrastructure with Playwright in Node.js for reliable web automation without the headaches."
-flags: ["guide", "playground"]
+flags: ["guide", "playground", "cli"]
 directory: "examples/steel-playwright-starter"
+groupId: "playwright-starter"
 language: "typescript"
 ---
 

--- a/mdx/puppeteer-typescript.mdx
+++ b/mdx/puppeteer-typescript.mdx
@@ -5,8 +5,9 @@ accentColor: "yellow"
 category: "BROWSER_AUTOMATION"
 stack: "nodejs"
 description: "Control Steel's managed browser infrastructure with Puppeteer in Node.js for reliable web automation without the headaches."
-flags: ["guide", "playground"]
+flags: ["guide", "playground", "cli"]
 directory: "examples/steel-puppeteer-starter"
+groupId: "puppeteer-starter"
 language: "typescript"
 ---
 

--- a/mdx/steel-claude-computer-use-node-starter.mdx
+++ b/mdx/steel-claude-computer-use-node-starter.mdx
@@ -7,5 +7,6 @@ stack: "nodejs"
 description: "A starter project demonstrating how to use Steel with Anthropic's Claude Computer Use API in Node.js to create a browser automation agent."
 flags: ["cli", "playground"]
 directory: "examples/steel-claude-computer-use-node-starter"
+groupId: "claude-computer-use"
 language: "typescript"
 --- 

--- a/mdx/steel-claude-computer-use-python-starter.mdx
+++ b/mdx/steel-claude-computer-use-python-starter.mdx
@@ -7,5 +7,6 @@ stack: "python"
 description: "A starter project demonstrating how to use Steel with Anthropic's Claude Computer Use API in Python to create a browser automation agent."
 flags: ["cli", "playground"]
 directory: "examples/steel-claude-computer-use-python-starter"
+groupId: "claude-computer-use"
 language: "python"
 --- 

--- a/mdx/steel-oai-computer-use-node-starter.mdx
+++ b/mdx/steel-oai-computer-use-node-starter.mdx
@@ -7,5 +7,6 @@ stack: "nodejs"
 description: "A starter project for integrating Steel with OpenAI's Computer Use Assistant API to create a browser automation agent."
 flags: ["cli", "playground"]
 directory: "examples/steel-oai-computer-use-node-starter"
+groupId: "oai-computer-use"
 language: "typescript"
 --- 

--- a/mdx/steel-oai-computer-use-python-starter.mdx
+++ b/mdx/steel-oai-computer-use-python-starter.mdx
@@ -7,5 +7,6 @@ stack: "python"
 description: "A starter project for integrating Steel with OpenAI's Computer Use Assistant API to create a browser automation agent."
 flags: ["cli", "playground"]
 directory: "examples/steel-oai-computer-use-python-starter"
+groupId: "oai-computer-use"
 language: "python"
 --- 

--- a/mdx/steel-playwright-starter-js.mdx
+++ b/mdx/steel-playwright-starter-js.mdx
@@ -7,5 +7,6 @@ stack: "nodejs"
 description: "A starter project for using Playwright with Steel on Node.js."
 flags: ["cli", "playground"]
 directory: "examples/steel-playwright-starter-js"
+groupId: "playwright-starter"
 language: "javascript"
 --- 

--- a/mdx/steel-puppeteer-starter-js.mdx
+++ b/mdx/steel-puppeteer-starter-js.mdx
@@ -7,5 +7,6 @@ stack: "nodejs"
 description: "A starter project for using Puppeteer with Steel on Node.js."
 flags: ["cli", "playground"]
 directory: "examples/steel-puppeteer-starter-js"
+groupId: "puppeteer-starter"
 language: "javascript"
---- 
+---

--- a/mdx/steel-stagehand-node-starter.mdx
+++ b/mdx/steel-stagehand-node-starter.mdx
@@ -7,5 +7,6 @@ stack: "nodejs"
 description: "A starter project demonstrating how to use Steel with Stagehand in Node.js & TypeScript for AI-powered browser automations."
 flags: ["cli", "playground"]
 directory: "examples/steel-stagehand-node-starter"
+groupId: "stagehand-starter"
 language: "typescript"
 --- 

--- a/mdx/steel-stagehand-python-starter.mdx
+++ b/mdx/steel-stagehand-python-starter.mdx
@@ -7,5 +7,6 @@ stack: "python"
 description: "A starter project demonstrating how to use Steel with Stagehand in Python for AI-powered browser automations."
 flags: ["cli", "playground"]
 directory: "examples/steel-stagehand-python-starter"
+groupId: "stagehand-starter"
 language: "python"
 --- 

--- a/schemas/v1/registry-groups.json
+++ b/schemas/v1/registry-groups.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["examples"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "examples": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "accentColor", "category", "description"],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "accentColor": {
+            "type": "string",
+            "enum": ["blue", "yellow", "orange", "purple", "green", "red"]
+          },
+          "category": {
+            "type": "string",
+            "enum": ["BROWSER_AUTOMATION", "AI_AUTOMATION"]
+          },
+          "description": { "type": "string" },
+          "flags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["cli", "guide", "playground"]
+            },
+            "uniqueItems": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/upload-schema.ts
+++ b/scripts/upload-schema.ts
@@ -1,0 +1,84 @@
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import "dotenv/config";
+
+const {
+  R2_ACCOUNT_ID,
+  R2_ACCESS_KEY_ID,
+  R2_SECRET_ACCESS_KEY,
+  R2_BUCKET_NAME,
+} = process.env;
+
+if (
+  !R2_ACCOUNT_ID ||
+  !R2_ACCESS_KEY_ID ||
+  !R2_SECRET_ACCESS_KEY ||
+  !R2_BUCKET_NAME
+) {
+  throw new Error("Missing one or more required R2 environment variables.");
+}
+
+const S3 = new S3Client({
+  region: "auto",
+  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: R2_ACCESS_KEY_ID,
+    secretAccessKey: R2_SECRET_ACCESS_KEY,
+  },
+});
+
+const directory = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.join(directory, "..");
+const SCHEMAS_DIR = path.join(ROOT_DIR, "./schemas");
+const SCHEMAS_PREFIX = "schemas/";
+
+async function getFilesRecursively(dir: string): Promise<string[]> {
+  const dirents = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    dirents.map((dirent) => {
+      const res = path.resolve(dir, dirent.name);
+      return dirent.isDirectory() ? getFilesRecursively(res) : res;
+    }),
+  );
+  return files.flat();
+}
+
+export async function main() {
+  console.log(`Uploading schema files from '${SCHEMAS_DIR}' to R2...`);
+
+  const allSchemaFiles = await getFilesRecursively(SCHEMAS_DIR);
+
+  if (allSchemaFiles.length === 0) {
+    console.log("No schema files found to upload.");
+    return;
+  }
+
+  const uploadPromises = allSchemaFiles.map(async (filePath) => {
+    const relativePath = path.relative(SCHEMAS_DIR, filePath);
+    const r2Key = `${SCHEMAS_PREFIX}${relativePath.replace(/\\/g, "/")}`;
+
+    const fileContent = await fs.readFile(filePath);
+    const contentType = "application/schema+json";
+
+    await S3.send(
+      new PutObjectCommand({
+        Bucket: R2_BUCKET_NAME,
+        Key: r2Key,
+        Body: fileContent,
+        ContentType: contentType,
+      }),
+    );
+    console.log(`  ✔ Uploaded ${relativePath} as ${r2Key}`);
+  });
+
+  await Promise.all(uploadPromises);
+
+  console.log(`\n✅ ${allSchemaFiles.length} schema files uploaded successfully!`);
+}
+
+main().catch((err) => {
+  console.error("\nAn unexpected error occurred:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
This adds a non-breaking change to the registry which adds a top level grouping which takes precedence over properties within the child. This is used to group examples into languages for the guide