### PR TITLE
fix(examples): use the real session timeout parameter

### DIFF
--- a/examples/agno/README.md
+++ b/examples/agno/README.md
@@ -58,7 +58,7 @@ The `finally` block in `main()` calls `tools.close_session()`, which releases th
 
 - **Change the task.** Set `TASK` in `.env` or edit the default in `main.py`.
 - **Add tools.** Append any method to the `tools` list in `SteelTools.__init__`: `click_selector(selector)`, `fill_form(field, value)`, `wait_for_text(text)`. Typed signature plus docstring, Agno handles the rest.
-- **Turn on stealth.** Pass flags to `self.client.sessions.create()` inside `_ensure_session`: `use_proxy=True`, `solve_captcha=True`, `session_timeout=600000`.
+- **Turn on stealth.** Pass flags to `self.client.sessions.create()` inside `_ensure_session`: `use_proxy=True`, `solve_captcha=True`, `api_timeout=600000`. The session duration is `api_timeout` because the Python SDK reserves `timeout` for the HTTP request.
 - **Swap the model.** `OpenAIChat(id="gpt-5-nano", ...)` is cheap and fast. Agno also ships `agno.models.anthropic.Claude` and others; the toolkit stays the same.
 
 ## Related

--- a/examples/browser-use-captcha-auto/README.md
+++ b/examples/browser-use-captcha-auto/README.md
@@ -79,7 +79,7 @@ A run usually finishes in under a minute: a few cents of Steel session time plus
 - **Point at a real target.** Replace the `TASK` string with the actual flow: "sign up at example.com with these details". Keep the instruction to call `wait_for_captcha_solution` when a CAPTCHA appears; everything else, the agent figures out.
 - **Tune the poll loop.** `wait_for_captcha_solution` uses `timeout_ms=60000` and `poll_interval_ms=1000`. Image grids and audio fallbacks sometimes need 90-120 seconds. A 2-3 second poll cuts API calls without noticeable delay.
 - **Fail loud on solver failure.** The current summary counts `failed` tasks but the tool does not short-circuit on them. Check `summary["failed_tasks"] > 0` inside the loop and return an error string so the agent can retry or abort.
-- **Combine with stealth.** `sessions.create()` accepts `use_proxy=True` and `session_timeout=1800000` alongside `solve_captcha=True`. Sites that CAPTCHA you aggressively usually want all three.
+- **Combine with stealth.** `sessions.create()` accepts `use_proxy=True` and `api_timeout=1800000` (the Python SDK's name for the session duration, since `timeout` is the HTTP request timeout) alongside `solve_captcha=True`. Sites that CAPTCHA you aggressively usually want all three.
 
 ## Related
 

--- a/examples/browser-use-captcha-manual/README.md
+++ b/examples/browser-use-captcha-manual/README.md
@@ -4,7 +4,7 @@ Steel can solve CAPTCHAs for you in the background, or it can hand you the statu
 
 ```python
 session = client.sessions.create(
-    timeout=300000,
+    api_timeout=300000,
     solve_captcha=True,
     stealth_config={"auto_captcha_solving": False},
 )

--- a/examples/browser-use-captcha-manual/main.py
+++ b/examples/browser-use-captcha-manual/main.py
@@ -267,7 +267,7 @@ async def main() -> None:
         # Create Steel session
         print("\nCreating Steel session with CAPTCHA solving enabled...")
         session = client.sessions.create(
-            timeout=300000,  # 5 minutes timeout for the session
+            api_timeout=300000,  # 5 minutes timeout for the session
             solve_captcha=True,
             stealth_config={
                 "auto_captcha_solving": False,  # Disable auto-solving for manual control

--- a/examples/browser-use/README.md
+++ b/examples/browser-use/README.md
@@ -54,7 +54,7 @@ A run costs a few cents of Steel session time plus OpenAI tokens for each step t
 ## Make it yours
 
 - **Change the task.** Set `TASK` in `.env` or edit the default in `main.py`. Any sentence works: "log in to example.com and download the latest invoice PDF", "compare prices for the top 3 vacuum cleaners on Amazon", "fill out the contact form at acme.com with these fields". Long tasks are fine; the agent breaks them into steps on its own.
-- **Turn on stealth.** Add `use_proxy=True`, `solve_captcha=True`, or `session_timeout=1800000` to the `sessions.create()` call for sites with anti-bot. Tasks that navigate logged-in areas usually need longer timeouts than the 5-minute default.
+- **Turn on stealth.** Add `use_proxy=True`, `solve_captcha=True`, or `api_timeout=1800000` to the `sessions.create()` call for sites with anti-bot. Tasks that navigate logged-in areas usually need longer timeouts than the 5-minute default. The session duration is `api_timeout` because the Python SDK reserves `timeout` for the HTTP request.
 - **Swap the model.** `ChatOpenAI(model="gpt-5", ...)` is the default; Browser Use also ships `ChatAnthropic`, `ChatGoogle`, and others. Change the import and the `model` arg passed to `Agent`.
 - **Persist login.** Reuse cookies and local storage across runs via [credentials](../credentials-ts) so the agent doesn't have to sign in every time.
 

--- a/examples/credentials-py/README.md
+++ b/examples/credentials-py/README.md
@@ -60,7 +60,7 @@ On a second run the credential already exists, so you see `Credential already ex
 
 - **Swap the target site.** Change `origin` and `value` in `credentials.create`, then update the `page.goto` URL and the login-trigger click in `main.py`. Steel detects the form as long as the page uses a standard username and password input pair.
 - **Manage credentials separately.** `client.credentials.list()`, `client.credentials.update(...)`, and `client.credentials.delete(...)` let you rotate or audit stored logins without touching the automation. Seed credentials from a one-off setup script and keep `main.py` about the workflow.
-- **Stack it with other session options.** `use_proxy`, `solve_captcha`, and `session_timeout` slot in next to `credentials={}` in `sessions.create()`. The vault coexists with every other knob.
+- **Stack it with other session options.** `use_proxy`, `solve_captcha`, and `api_timeout` slot in next to `credentials={}` in `sessions.create()`. The vault coexists with every other knob. `api_timeout` is the session duration; the Python SDK keeps `timeout` for the HTTP request.
 
 ## When to use this vs. auth-context
 

--- a/examples/credentials-ts/README.md
+++ b/examples/credentials-ts/README.md
@@ -70,7 +70,7 @@ On a second run the credential already exists, so you see `Credential already ex
 
 - **Swap the target site.** Change the `origin` and `value` in `credentials.create`, then update `page.goto` and the login-trigger click in `index.ts`. Steel handles the form detection as long as the page exposes a standard username/password input pair.
 - **Manage credentials out of band.** `client.credentials.list()`, `client.credentials.retrieve(id)`, and `client.credentials.delete(id)` let you rotate or audit stored creds without touching automation code. Create credentials from a setup script and keep `index.ts` focused on the workflow.
-- **Combine with stealth.** Pass `useProxy`, `solveCaptcha`, or `sessionTimeout` alongside `credentials: {}` in `sessions.create()`. The vault works with every other session option.
+- **Combine with stealth.** Pass `useProxy`, `solveCaptcha`, or `timeout` alongside `credentials: {}` in `sessions.create()`. The vault works with every other session option.
 
 ## When to use this vs. auth-context
 

--- a/examples/extensions-ts/index.ts
+++ b/examples/extensions-ts/index.ts
@@ -74,7 +74,7 @@ async function main() {
       // useProxy: true, // Use Steel's proxy network (residential IPs)
       // proxyUrl: 'http://...',         // Use your own proxy (format: protocol://username:password@host:port)
       // solveCaptcha: true,             // Enable automatic CAPTCHA solving
-      // sessionTimeout: 1800000,        // Session timeout in ms (default: 5 mins)
+      // timeout: 1800000,               // Session timeout in ms (default: 5 mins)
       // === Browser Configuration ===
       // userAgent: 'custom-ua-string',  // Set a custom User-Agent
       extensionIds: extension?.id ? [extension.id] : [],

--- a/examples/files-ts/index.ts
+++ b/examples/files-ts/index.ts
@@ -43,7 +43,7 @@ async function main() {
       // useProxy: true, // Use Steel's proxy network (residential IPs)
       // proxyUrl: 'http://...',         // Use your own proxy (format: protocol://username:password@host:port)
       // solveCaptcha: true,             // Enable automatic CAPTCHA solving
-      // sessionTimeout: 1800000,        // Session timeout in ms (default: 5 mins)
+      // timeout: 1800000,               // Session timeout in ms (default: 5 mins)
       // === Browser Configuration ===
       // userAgent: 'custom-ua-string',  // Set a custom User-Agent
     });

--- a/examples/google-adk-ts/README.md
+++ b/examples/google-adk-ts/README.md
@@ -91,7 +91,7 @@ This agent has no `outputSchema`. ADK disables tool calls when an output schema 
 - **Add a tool.** A `click` tool wrapping `page.click`, or a `screenshot` tool returning a base64 PNG. Build it with `new FunctionTool({ name, description, parameters, execute })` and add it to the agent's `tools` array.
 - **Persist sessions.** Swap `InMemoryRunner` for a `Runner` with a `DatabaseSessionService` to keep conversation state across runs; the session ID is the thread key.
 - **Run Vertex instead of AI Studio.** Set `GOOGLE_GENAI_USE_VERTEXAI=TRUE` plus `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`, and construct `new Gemini({ model, vertexai: true })`.
-- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or `sessionTimeout` to `steel.sessions.create({...})` for sites with anti-bot.
+- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or `timeout` to `steel.sessions.create({...})` for sites with anti-bot.
 
 ## Related
 

--- a/examples/magnitude/README.md
+++ b/examples/magnitude/README.md
@@ -102,7 +102,7 @@ A full run takes ~45 seconds. The `finally` block stops the agent first, then re
 - **Swap the schema and prompt.** `extract()` is schema-driven: forms, tables, invoices, search results.
 - **Chain `act` calls for multi-step flows.** Login, filter, paginate, export. Each step is one natural-language instruction.
 - **Switch models.** `llm.provider` accepts `"anthropic"` (used here) among others. Point `model` and `apiKey` at a different provider in `startBrowserAgent()`.
-- **Turn on stealth.** Uncomment `useProxy`, `solveCaptcha`, or `sessionTimeout` in `client.sessions.create()` for sites with anti-bot.
+- **Turn on stealth.** Uncomment `useProxy`, `solveCaptcha`, or `timeout` in `client.sessions.create()` for sites with anti-bot.
 
 ## Related
 

--- a/examples/magnitude/index.ts
+++ b/examples/magnitude/index.ts
@@ -53,7 +53,7 @@ async function main() {
       // useProxy: true, // Use Steel's proxy network (residential IPs)
       // proxyUrl: 'http://...',         // Use your own proxy (format: protocol://username:password@host:port)
       // solveCaptcha: true,             // Enable automatic CAPTCHA solving
-      // sessionTimeout: 1800000,        // Session timeout in ms (default: 5 mins)
+      // timeout: 1800000,               // Session timeout in ms (default: 5 mins)
       // === Browser Configuration ===
       // userAgent: 'custom-ua-string',  // Set a custom User-Agent
     });

--- a/examples/mastra/README.md
+++ b/examples/mastra/README.md
@@ -90,7 +90,7 @@ It serves at `http://localhost:4111` and reads the `mastra` registry exported fr
 - **Add a tool.** A `click` tool wrapping `page.click`, a `screenshot` tool returning a base64 PNG. Add to the `tools` record.
 - **Add memory.** Install `@mastra/memory` plus a storage adapter (`@mastra/libsql`), pass `memory` on the `Agent`, then call `generate(prompt, { memory: { resource, thread } })` to persist conversation across runs. See [Mastra memory docs](https://mastra.ai/docs/memory/overview).
 - **Wrap it in a workflow.** For multi-step pipelines (login → scrape → summarize) where each step needs to be retryable or human-resumable, port the tool calls into `createStep` blocks under a `createWorkflow`. See [Mastra workflows](https://mastra.ai/docs/workflows/overview).
-- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or `sessionTimeout` to `steel.sessions.create({...})` for sites with anti-bot.
+- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or `timeout` to `steel.sessions.create({...})` for sites with anti-bot.
 
 ## Related
 

--- a/examples/notte/README.md
+++ b/examples/notte/README.md
@@ -63,7 +63,7 @@ A default run takes ~25 seconds. The `finally` block calls `client.sessions.rele
 - **Raise `max_steps`.** Bump the ceiling on `notte.Agent(...)` for multi-page flows.
 - **Swap the reasoning model.** Change `reasoning_model` on `notte.Agent`. Flash for speed, GPT-5 or Sonnet for ambiguity.
 - **Switch to deep perception.** Pass `perception_type="deep"` to `notte.Session(...)` when the fast heuristics miss elements.
-- **Turn on stealth.** Add `use_proxy=True`, `solve_captcha=True`, or `session_timeout=1800000` to `client.sessions.create()` for sites with anti-bot.
+- **Turn on stealth.** Add `use_proxy=True`, `solve_captcha=True`, or `api_timeout=1800000` to `client.sessions.create()` for sites with anti-bot. The session duration is `api_timeout`; the Python SDK keeps `timeout` for the HTTP request.
 
 ## Related
 

--- a/examples/openai-agents-ts/README.md
+++ b/examples/openai-agents-ts/README.md
@@ -73,7 +73,7 @@ A full run is ~20-40 seconds. Cost is a few cents of Steel session time plus Ope
 - **Add handoffs.** Pass `handoffs: [writerAgent]` on the `Agent`. The SDK routes between agents based on each one's description.
 - **Add a guardrail.** Wire `inputGuardrails` or `outputGuardrails` on the `Agent` to vet the user's prompt or the final message. See the [guardrails guide](https://openai.github.io/openai-agents-js/guides/guardrails).
 - **Use a stronger model.** `model: "gpt-5"` plans better on ambiguous pages at the cost of tokens and latency.
-- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or a longer `sessionTimeout` to `sessions.create()` for sites with anti-bot.
+- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or a longer `timeout` to `sessions.create()` for sites with anti-bot.
 
 ## Related
 

--- a/examples/playwright-py/README.md
+++ b/examples/playwright-py/README.md
@@ -59,7 +59,7 @@ One run costs a few cents of session time. Steel bills per session-minute, which
 ## Make it yours
 
 - **Swap the target.** The scraping logic lives between the `Your Automations Go Here!` banner comments in `main.py`. Replace `page.goto` and the `story_rows` loop with your own selectors. Session setup, auth, and teardown stay the same.
-- **Harden for anti-bot.** Uncomment `use_proxy`, `solve_captcha`, or `session_timeout` inside `client.sessions.create()` for sites that fingerprint or challenge headless traffic.
+- **Harden for anti-bot.** Uncomment `use_proxy`, `solve_captcha`, or `api_timeout` inside `client.sessions.create()` for sites that fingerprint or challenge headless traffic. `api_timeout` is the session duration; the Python SDK reserves `timeout` for the HTTP request.
 - **Go async.** If you need parallel pages, switch `from playwright.sync_api import sync_playwright` to `playwright.async_api` and rewrite `main()` as `async def`. The Steel connection call is identical, just awaited.
 - **Persist login.** Carry cookies and local storage between runs with [credentials](../credentials-ts).
 

--- a/examples/playwright-py/main.py
+++ b/examples/playwright-py/main.py
@@ -41,7 +41,7 @@ def main():
             # use_proxy=True,              # Use Steel's proxy network (residential IPs)
             # proxy_url='http://...',      # Use your own proxy (format: protocol://username:password@host:port)
             # solve_captcha=True,          # Enable automatic CAPTCHA solving
-            # session_timeout=1800000,     # Session timeout in ms (default: 5 mins)
+            # api_timeout=1800000,         # Session timeout in ms (default: 5 mins)
             # === Browser Configuration ===
             # user_agent='custom-ua',      # Set a custom User-Agent
         )

--- a/examples/playwright-ts/README.md
+++ b/examples/playwright-ts/README.md
@@ -57,7 +57,7 @@ A run costs a few cents of browser time. Steel bills per session-minute, so the 
 ## Make it yours
 
 - **Swap the target.** Replace the `page.goto` URL and the `page.evaluate` body in `index.ts`. Session setup, auth, and cleanup stay the same.
-- **Turn on stealth.** Uncomment `useProxy`, `solveCaptcha`, or `sessionTimeout` in the `sessions.create()` call for sites with anti-bot.
+- **Turn on stealth.** Uncomment `useProxy`, `solveCaptcha`, or `timeout` in the `sessions.create()` call for sites with anti-bot.
 - **Persist login.** Reuse cookies and local storage across runs via [credentials](../credentials-ts).
 
 ## Related

--- a/examples/playwright-ts/index.ts
+++ b/examples/playwright-ts/index.ts
@@ -42,7 +42,7 @@ async function main() {
       // useProxy: true, // Use Steel's proxy network (residential IPs)
       // proxyUrl: 'http://...',         // Use your own proxy (format: protocol://username:password@host:port)
       // solveCaptcha: true,             // Enable automatic CAPTCHA solving
-      // sessionTimeout: 1800000,        // Session timeout in ms (default: 5 mins)
+      // timeout: 1800000,               // Session timeout in ms (default: 5 mins)
       // === Browser Configuration ===
       // userAgent: 'custom-ua-string',  // Set a custom User-Agent
     });

--- a/examples/puppeteer-ts/README.md
+++ b/examples/puppeteer-ts/README.md
@@ -57,7 +57,7 @@ A run costs a few cents of browser time. Steel bills per session-minute, so the 
 ## Make it yours
 
 - **Swap the target.** Replace the `page.goto` URL and the `page.evaluate` body in `main()`. Session setup, connect, and cleanup stay the same.
-- **Turn on stealth.** Uncomment `useProxy`, `solveCaptcha`, or `sessionTimeout` in the `sessions.create()` call for sites with anti-bot.
+- **Turn on stealth.** Uncomment `useProxy`, `solveCaptcha`, or `timeout` in the `sessions.create()` call for sites with anti-bot.
 - **Persist login.** Reuse cookies and local storage across runs via [credentials](../credentials-ts).
 
 ## Related

--- a/examples/puppeteer-ts/index.ts
+++ b/examples/puppeteer-ts/index.ts
@@ -41,7 +41,7 @@ async function main() {
       // useProxy: true, // Use Steel's proxy network (residential IPs)
       // proxyUrl: 'http://...',         // Use your own proxy (format: protocol://username:password@host:port)
       // solveCaptcha: true,             // Enable automatic CAPTCHA solving
-      // sessionTimeout: 1800000,        // Session timeout in ms (default: 5 mins)
+      // timeout: 1800000,               // Session timeout in ms (default: 5 mins)
       // === Browser Configuration ===
       // userAgent: 'custom-ua-string',  // Set a custom User-Agent
     });

--- a/examples/selenium/README.md
+++ b/examples/selenium/README.md
@@ -79,7 +79,7 @@ A run costs a few cents of session time. Steel bills per session-minute, so `mai
 ## Make it yours
 
 - **Swap the target.** The scraping logic sits between the `Your Automations Go Here!` banner comments in `main.py`. Replace `driver.get(...)` and the `story_elements` loop with your own selectors; session setup and teardown stay put.
-- **Extend the session.** Pass `session_timeout=1800000` (30 minutes) alongside `is_selenium=True` in `sessions.create()` for longer runs. Keep `is_selenium=True`; it is the switch that provisions a WebDriver node.
+- **Extend the session.** Pass `api_timeout=1800000` (30 minutes) alongside `is_selenium=True` in `sessions.create()` for longer runs. Keep `is_selenium=True`; it is the switch that provisions a WebDriver node. The session duration is `api_timeout` because the Python SDK reserves `timeout` for the HTTP request.
 - **Wait on DOM state.** Each command is an HTTP round-trip, so blind `time.sleep` calls compound latency. Prefer `WebDriverWait` with `expected_conditions` (as in the example) to block on the specific element or state you need.
 - **Reuse the headers pattern.** `CustomRemoteConnection` is how you inject any extra header into every WebDriver request. The same subclass shape works for custom tracing or routing headers you want to attach per call.
 

--- a/examples/selenium/main.py
+++ b/examples/selenium/main.py
@@ -53,7 +53,7 @@ def main():
         # Create a new Steel session with is_selenium=True
         session = client.sessions.create(
             is_selenium=True,              # Enable Selenium mode (required)
-            # session_timeout=1800000,     # Session timeout in ms (default: 5 mins)
+            # api_timeout=1800000,         # Session timeout in ms (default: 5 mins)
         )
         print(session)
 

--- a/examples/stagehand-py/README.md
+++ b/examples/stagehand-py/README.md
@@ -128,7 +128,7 @@ A full run takes ~30 seconds. The `finally` block in `main()` calls `stagehand.s
 - **Swap the schema and prompt.** `STORY_SCHEMA` and the `sessions.extract` instruction in `main.py` are the only parts tied to the Hacker News demo.
 - **Chain acts and extracts.** Break a task into natural-language steps, one `await _stream_to_result(...)` per step.
 - **Try another model.** `openai/gpt-5` is a reasonable default; Claude and Gemini also work. Change `model_name` on `sessions.start` and point `model_api_key` at the matching provider.
-- **Turn on Steel stealth.** Uncomment `use_proxy`, `solve_captcha`, or `session_timeout` in the `client.sessions.create()` call for sites with anti-bot.
+- **Turn on Steel stealth.** Uncomment `use_proxy`, `solve_captcha`, or `api_timeout` in the `client.sessions.create()` call for sites with anti-bot. `api_timeout` sets the session duration; the Python SDK keeps `timeout` for the HTTP request.
 
 ## Related
 

--- a/examples/stagehand-py/main.py
+++ b/examples/stagehand-py/main.py
@@ -83,7 +83,7 @@ async def main():
             # use_proxy=True,              # Use Steel's proxy network (residential IPs)
             # proxy_url='http://...',      # Use your own proxy (format: protocol://username:password@host:port)
             # solve_captcha=True,          # Enable automatic CAPTCHA solving
-            # session_timeout=1800000,     # Session timeout in ms (default: 5 mins)
+            # api_timeout=1800000,         # Session timeout in ms (default: 5 mins)
             # === Browser Configuration ===
             # user_agent='custom-ua',      # Set a custom User-Agent
         )

--- a/examples/stagehand-ts/index.ts
+++ b/examples/stagehand-ts/index.ts
@@ -55,7 +55,7 @@ async function main() {
       // useProxy: true, // Use Steel's proxy network (residential IPs)
       // proxyUrl: 'http://...',         // Use your own proxy (format: protocol://username:password@host:port)
       // solveCaptcha: true,             // Enable automatic CAPTCHA solving
-      // sessionTimeout: 1800000,        // Session timeout in ms (default: 5 mins)
+      // timeout: 1800000,               // Session timeout in ms (default: 5 mins)
       // === Browser Configuration ===
       // userAgent: 'custom-ua-string',  // Set a custom User-Agent
     });

--- a/examples/trigger-dev-browser-job/README.md
+++ b/examples/trigger-dev-browser-job/README.md
@@ -14,7 +14,7 @@ export const browserJob = task({
   retry: { maxAttempts: 3 },
   queue: { concurrencyLimit: 2 },
   run: async (payload) => {
-    session = await steel.sessions.create({ sessionTimeout: 600000 });
+    session = await steel.sessions.create({ timeout: 600000 });
     browser = await chromium.connectOverCDP(
       `${session.websocketUrl}&apiKey=${steelApiKey}`
     );

--- a/examples/trigger-dev-browser-job/src/trigger/browser-job.ts
+++ b/examples/trigger-dev-browser-job/src/trigger/browser-job.ts
@@ -96,7 +96,7 @@ export const browserJob = task({
 
       session = await steel.sessions.create({
         blockAds: true,
-        sessionTimeout: 600000,
+        timeout: 600000,
       });
 
       logger.info("Steel session ready", {

--- a/examples/vercel-ai-sdk-nextjs/README.md
+++ b/examples/vercel-ai-sdk-nextjs/README.md
@@ -71,7 +71,7 @@ The `/api/chat` route already declares `maxDuration = 120` and `runtime = "nodej
 - **Change the model.** Swap `anthropic("claude-haiku-4-5")` for any model in `@ai-sdk/*`. The Zod tool schemas stay the same.
 - **Add a screenshot tool.** `await page.screenshot({ type: "png" })` returns a Buffer; return it base64-encoded and render it as an `<img>` in the tool-call panel.
 - **Stream a plan step.** Add a `plan` tool with no side effects and a string input. The model can narrate its intent before executing.
-- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or `sessionTimeout` options to `steel.sessions.create()` inside `openSession`.
+- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or `timeout` options to `steel.sessions.create()` inside `openSession`.
 - **Wire the approval UI.** `needsApproval: true` on `submitForm` pauses execution and surfaces the call as a `tool-submitForm` part in `state: "input-available"`. Render an Approve/Reject pair and call `addToolResult` from `@ai-sdk/react` to resume.
 
 ## Related

--- a/examples/vercel-ai-sdk-ts/README.md
+++ b/examples/vercel-ai-sdk-ts/README.md
@@ -65,7 +65,7 @@ A full run takes ~20 seconds and costs a few cents of Steel session time plus a 
 - **Swap the model.** `claude-haiku-4-5` is the default. For harder tasks, try `anthropic("claude-sonnet-4-6")`, `openai("gpt-5")`, or `google("gemini-2.5-pro")`. You can also use the [AI Gateway](https://vercel.com/docs/ai-gateway) string form, like `"anthropic/claude-haiku-4-5"`, to route through Vercel.
 - **Add tools.** A `click` tool wrapping `page.click`, a `fill` tool over `page.fill`, a `screenshot` tool that returns a base64 PNG for vision models.
 - **Phase-gate steps.** Use `prepareStep` to restrict which tools are callable on a given step. See the AI SDK's [loop control](https://ai-sdk.dev/docs/agents/loop-control) page.
-- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or `sessionTimeout` to `steel.sessions.create({...})` inside `openSession` for sites with anti-bot.
+- **Turn on stealth.** Pass `useProxy`, `solveCaptcha`, or `timeout` to `steel.sessions.create({...})` inside `openSession` for sites with anti-bot.
 
 ## Related
 


### PR DESCRIPTION
## What

`sessionTimeout` / `session_timeout` appears in 28 places across 28 files. It exists in no Steel SDK and not in the REST API.

| Surface | Session timeout | Custom ID |
|---|---|---|
| REST API | `timeout` (default 300000 ms), `inactivityTimeout` | `sessionId` |
| steel-node | `timeout` | `sessionId` |
| steel-python | `api_timeout` (wire alias `timeout`) | `session_id` |
| steel-go | `Timeout` | `SessionID` |
| steel-rust | `timeout` | `session_id` |

`timeout` is unavailable in Python because the HTTP client reserves it, hence `api_timeout`.

## Why it matters

Python raises `TypeError: unexpected keyword argument`. TypeScript is worse: a compile error under strict excess-property checks, or silently dropped in plain JS, so the session keeps the five-minute default and dies mid-run.

`examples/trigger-dev-browser-job` passed it in **live code**, so the recipe did not typecheck:

```
$ npm run typecheck   # before
src/trigger/browser-job.ts(97,38): error TS2769: No overload matches this call.
    Object literal may only specify known properties, and 'sessionTimeout' does not exist in type 'SessionCreateParams'.
```

After the fix, that error is gone. The remaining `trigger.config.ts` `maxDuration` error is pre-existing and unrelated (it reproduces on `main`).

## Changes

- 7 TypeScript source files: `sessionTimeout` to `timeout` (6 commented option lines plus the one live call), trailing-comment alignment preserved
- 3 Python source files: `session_timeout` to `api_timeout`
- 18 README bullets, matching. Python bullets now say why the name differs from the API field, since `api_timeout` reads like a typo otherwise.

## Verification

```
rg -c 'sessionTimeout|session_timeout' .   # no matches
npm run typecheck                          # in trigger-dev-browser-job, clean apart from the pre-existing config error
python3 -m py_compile <the 3 changed .py files>
```

## Follow-up

Blocks steel-dev/docs#79. `scripts/sync-cookbook.ts` regenerates 18 spots in `content/docs/cookbook/` from these READMEs, so the docs fix is a lock bump plus re-sync once this merges.

## Second commit: a related timeout defect found while auditing this PR

`browser-use-captcha-manual` passed `timeout=300000` to `sessions.create()`. That type-checks, because `timeout` is the per-request HTTP option, so nothing flagged it. But `sessions.py` resolves the body field as `api_timeout or timeout` **and** forwards `timeout` into `make_request_options`:

```python
"api_timeout": api_timeout or timeout,
...
options=make_request_options(..., timeout=timeout)
```

So the body came out correct while the call also set a 300000-second httpx timeout, disabling the request timeout as a side effect. `api_timeout=300000` gives the same body with no side effect. Fixed in `main.py` and the README.
